### PR TITLE
multiTooltipTitleTemplate

### DIFF
--- a/Chart.js
+++ b/Chart.js
@@ -168,8 +168,11 @@
 			// String - Template string for single tooltips
 			tooltipTemplate: "<%if (label){%><%=label%>: <%}%><%= value %>",
 
-			// String - Template string for single tooltips
+			// String - Template string for multiple tooltip
 			multiTooltipTemplate: "<%= value %>",
+
+        		// String - Template string for multiple tooltip title
+        		multiTooltipTitleTemplate: "Tooltip title <%= label %>",
 
 			// String - Colour behind the legend colour block
 			multiTooltipKeyBackground: '#fff',
@@ -1015,7 +1018,7 @@
 						labels: tooltipLabels,
 						legendColors: tooltipColors,
 						legendColorBackground : this.options.multiTooltipKeyBackground,
-						title: ChartElements[0].label,
+						title: template(this.options.multiTooltipTitleTemplate, ChartElements[0]),
 						chart: this.chart,
 						ctx: this.chart.ctx,
 						custom: this.options.customTooltips


### PR DESCRIPTION
(issue https://github.com/nnnick/Chart.js/issues/499)
multiTooltipTitleTemplate allows to template title in multiTooltip. 
Example: set option  
multiTooltipTitleTemplate: "My text <%= label %> - <%= value %>",